### PR TITLE
add class variables

### DIFF
--- a/src/QueryBuilder/QueryBuilderHandler.php
+++ b/src/QueryBuilder/QueryBuilderHandler.php
@@ -37,6 +37,16 @@ class QueryBuilderHandler
     protected $tablePrefix = null;
 
     /**
+     * @var string
+     */
+    protected $adapter;
+
+    /**
+     * @var array
+     */
+    protected $adapterConfig;
+
+    /**
      * @var \WpFluent\QueryBuilder\Adapters\BaseAdapter
      */
     protected $adapterInstance;


### PR DESCRIPTION
PHP 8.2 emits notices that creation of dynamic properties is deprecated. There are 2 missing properties in the QueryBuilderHandler class, adding these prevents that notice from coming up.